### PR TITLE
Add the MatchResult class to MessageMatcher

### DIFF
--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/MessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/MessageMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 
 package org.springframework.security.messaging.util.matcher;
+
+import java.util.Collections;
+import java.util.Map;
 
 import org.springframework.messaging.Message;
 
@@ -49,5 +52,78 @@ public interface MessageMatcher<T> {
 	 * @return true if the {@link Message} matches, else false
 	 */
 	boolean matches(Message<? extends T> message);
+
+	/**
+	 * Returns a {@link MatchResult} for this {@code MessageMatcher}. The default
+	 * implementation returns {@link Collections#emptyMap()} when
+	 * {@link MatchResult#getVariables()} is invoked.
+	 * @return the {@code MatchResult} from comparing this {@code MessageMatcher} against
+	 * the {@code Message}
+	 * @since 6.5
+	 */
+	default MatchResult matcher(Message<? extends T> message) {
+		boolean match = matches(message);
+		return new MatchResult(match, Collections.emptyMap());
+	}
+
+	/**
+	 * The result of matching against a {@code Message} contains the status, true or
+	 * false, of the match and if present, any variables extracted from the match
+	 *
+	 * @since 6.5
+	 */
+	class MatchResult {
+
+		private final boolean match;
+
+		private final Map<String, String> variables;
+
+		MatchResult(boolean match, Map<String, String> variables) {
+			this.match = match;
+			this.variables = variables;
+		}
+
+		/**
+		 * Return whether the comparison against the {@code Message} produced a successful
+		 * match
+		 */
+		public boolean isMatch() {
+			return this.match;
+		}
+
+		/**
+		 * Returns the extracted variable values where the key is the variable name and
+		 * the value is the variable value
+		 * @return a map containing key-value pairs representing extracted variable names
+		 * and variable values
+		 */
+		public Map<String, String> getVariables() {
+			return this.variables;
+		}
+
+		/**
+		 * Creates an instance of {@link MatchResult} that is a match with no variables
+		 */
+		public static MatchResult match() {
+			return new MatchResult(true, Collections.emptyMap());
+		}
+
+		/**
+		 * Creates an instance of {@link MatchResult} that is a match with the specified
+		 * variables
+		 */
+		public static MatchResult match(Map<String, String> variables) {
+			return new MatchResult(true, variables);
+		}
+
+		/**
+		 * Creates an instance of {@link MatchResult} that is not a match.
+		 * @return a {@code MatchResult} with match set to false
+		 */
+		public static MatchResult notMatch() {
+			return new MatchResult(false, Collections.emptyMap());
+		}
+
+	}
 
 }


### PR DESCRIPTION
### **User description**
Closes gh-16766

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `MatchResult` class for `MessageMatcher`.

- Added methods to handle match results and extracted variables.

- Enhanced `MessageMatcher` with default `matcher` implementation.

- Updated copyright year to 2025.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MessageMatcher.java</strong><dd><code>Introduced `MatchResult` and enhanced `MessageMatcher`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

messaging/src/main/java/org/springframework/security/messaging/util/matcher/MessageMatcher.java

<li>Added <code>MatchResult</code> class to encapsulate match results.<br> <li> Introduced methods for match status and variable extraction.<br> <li> Added default <code>matcher</code> method to <code>MessageMatcher</code>.<br> <li> Updated copyright year to 2025.


</details>


  </td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/9/files#diff-c01528b51e364d2e214ca4ef9489246b28f3dc7fd8e04c75e431c77f9449d4f7">+77/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>