### PR TITLE
Final commit spring security before improvements

### DIFF
--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtEncoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtEncoder.java
@@ -87,17 +87,12 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 
 	private final JWKSource<SecurityContext> jwkSource;
 
-	private Converter<List<JWK>, JWK> jwkSelector= (jwks)->{
-		if (jwks.size() > 1) {
-			throw new JwtEncodingException(String.format(
-					"Failed to select a key since there are multiple for the signing algorithm [%s]; " +
-							"please specify a selector in NimbusJwsEncoder#setJwkSelector",jwks.get(0).getAlgorithm()));
-		}
-		if (jwks.isEmpty()) {
-			throw new JwtEncodingException(
-					String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to select a JWK signing key"));
-		}
-		return jwks.get(0);
+	private Converter<List<JWK>, JWK> jwkSelector = (jwks) -> {
+		throw new JwtEncodingException(
+				String.format(
+						"Failed to select a key since there are multiple for the signing algorithm [%s]; "
+								+ "please specify a selector in NimbusJwsEncoder#setJwkSelector",
+						jwks.get(0).getAlgorithm()));
 	};
 
 	/**
@@ -108,17 +103,20 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 		Assert.notNull(jwkSource, "jwkSource cannot be null");
 		this.jwkSource = jwkSource;
 	}
+
 	/**
-	 * Use this strategy to reduce the list of matching JWKs down to a since one.
-	 * <p> For example, you can call {@code setJwkSelector(List::getFirst)} in order
-	 * to have this encoder select the first match.
+	 * Use this strategy to reduce the list of matching JWKs when there is more than one.
+	 * <p>
+	 * For example, you can call {@code setJwkSelector(List::getFirst)} in order to have
+	 * this encoder select the first match.
 	 *
-	 * <p> By default, the class with throw an exception if there is more than one result.
+	 * <p>
+	 * By default, the class with throw an exception.
 	 * @since 6.5
 	 */
 	public void setJwkSelector(Converter<List<JWK>, JWK> jwkSelector) {
-		if(null!=jwkSelector)
-			this.jwkSelector = jwkSelector;
+		Assert.notNull(jwkSelector, "jwkSelector cannot be null");
+		this.jwkSelector = jwkSelector;
 	}
 
 	@Override
@@ -148,6 +146,13 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 		catch (Exception ex) {
 			throw new JwtEncodingException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE,
 					"Failed to select a JWK signing key -> " + ex.getMessage()), ex);
+		}
+		if (jwks.isEmpty()) {
+			throw new JwtEncodingException(
+					String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to select a JWK signing key"));
+		}
+		if (jwks.size() == 1) {
+			return jwks.get(0);
 		}
 		return this.jwkSelector.convert(jwks);
 	}

--- a/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtEncoder.java
+++ b/oauth2/oauth2-jose/src/main/java/org/springframework/security/oauth2/jwt/NimbusJwtEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -86,6 +87,19 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 
 	private final JWKSource<SecurityContext> jwkSource;
 
+	private Converter<List<JWK>, JWK> jwkSelector= (jwks)->{
+		if (jwks.size() > 1) {
+			throw new JwtEncodingException(String.format(
+					"Failed to select a key since there are multiple for the signing algorithm [%s]; " +
+							"please specify a selector in NimbusJwsEncoder#setJwkSelector",jwks.get(0).getAlgorithm()));
+		}
+		if (jwks.isEmpty()) {
+			throw new JwtEncodingException(
+					String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to select a JWK signing key"));
+		}
+		return jwks.get(0);
+	};
+
 	/**
 	 * Constructs a {@code NimbusJwtEncoder} using the provided parameters.
 	 * @param jwkSource the {@code com.nimbusds.jose.jwk.source.JWKSource}
@@ -93,6 +107,18 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 	public NimbusJwtEncoder(JWKSource<SecurityContext> jwkSource) {
 		Assert.notNull(jwkSource, "jwkSource cannot be null");
 		this.jwkSource = jwkSource;
+	}
+	/**
+	 * Use this strategy to reduce the list of matching JWKs down to a since one.
+	 * <p> For example, you can call {@code setJwkSelector(List::getFirst)} in order
+	 * to have this encoder select the first match.
+	 *
+	 * <p> By default, the class with throw an exception if there is more than one result.
+	 * @since 6.5
+	 */
+	public void setJwkSelector(Converter<List<JWK>, JWK> jwkSelector) {
+		if(null!=jwkSelector)
+			this.jwkSelector = jwkSelector;
 	}
 
 	@Override
@@ -123,18 +149,7 @@ public final class NimbusJwtEncoder implements JwtEncoder {
 			throw new JwtEncodingException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE,
 					"Failed to select a JWK signing key -> " + ex.getMessage()), ex);
 		}
-
-		if (jwks.size() > 1) {
-			throw new JwtEncodingException(String.format(ENCODING_ERROR_MESSAGE_TEMPLATE,
-					"Found multiple JWK signing keys for algorithm '" + headers.getAlgorithm().getName() + "'"));
-		}
-
-		if (jwks.isEmpty()) {
-			throw new JwtEncodingException(
-					String.format(ENCODING_ERROR_MESSAGE_TEMPLATE, "Failed to select a JWK signing key"));
-		}
-
-		return jwks.get(0);
+		return this.jwkSelector.convert(jwks);
 	}
 
 	private String serialize(JwsHeader headers, JwtClaimsSet claims, JWK jwk) {

--- a/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jose/TestJwks.java
+++ b/oauth2/oauth2-jose/src/test/java/org/springframework/security/oauth2/jose/TestJwks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,10 @@ public final class TestJwks {
 	// @formatter:on
 
 	private TestJwks() {
+	}
+
+	public static RSAKey.Builder rsa() {
+		return jwk(TestKeys.DEFAULT_PUBLIC_KEY, TestKeys.DEFAULT_PRIVATE_KEY);
 	}
 
 	public static RSAKey.Builder jwk(RSAPublicKey publicKey, RSAPrivateKey privateKey) {


### PR DESCRIPTION
<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

## Summary by Sourcery

Enhance JWT encoder key selection mechanism in Spring Security OAuth2 JOSE module

New Features:
- Add a new method setJwkSelector() to allow custom key selection when multiple JWKs are available

Enhancements:
- Introduce a configurable JWK selector strategy for handling multiple matching keys during JWT encoding
- Update error handling and key selection logic in NimbusJwtEncoder

Tests:
- Add comprehensive test cases for different JWK selection scenarios, including single key, multiple keys, and no keys