### PR TITLE
16635 initial commit

### DIFF
--- a/config/src/test/java/org/springframework/security/config/annotation/web/socket/WebSocketMessageBrokerSecurityConfigurationDocTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/socket/WebSocketMessageBrokerSecurityConfigurationDocTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/src/test/java/org/springframework/security/config/annotation/web/socket/WebSocketMessageBrokerSecurityConfigurationTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/web/socket/WebSocketMessageBrokerSecurityConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/messaging/src/main/java/org/springframework/security/messaging/access/intercept/MessageMatcherDelegatingAuthorizationManager.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/access/intercept/MessageMatcherDelegatingAuthorizationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.security.messaging.access.intercept;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -32,6 +33,7 @@ import org.springframework.security.authorization.AuthorityAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.messaging.util.matcher.DestinationPathPatternMessageMatcher;
 import org.springframework.security.messaging.util.matcher.MessageMatcher;
 import org.springframework.security.messaging.util.matcher.SimpDestinationMessageMatcher;
 import org.springframework.security.messaging.util.matcher.SimpMessageTypeMatcher;
@@ -87,12 +89,11 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		if (!matcher.matches((Message) message)) {
 			return null;
 		}
-		if (matcher instanceof SimpDestinationMessageMatcher simp) {
-			return new MessageAuthorizationContext<>(message, simp.extractPathVariables(message));
+		if (matcher instanceof Builder.LazySimpDestinationMessageMatcher pathMatcher) {
+			return new MessageAuthorizationContext<>(message, pathMatcher.extractPathVariables(message));
 		}
-		if (matcher instanceof Builder.LazySimpDestinationMessageMatcher) {
-			Builder.LazySimpDestinationMessageMatcher path = (Builder.LazySimpDestinationMessageMatcher) matcher;
-			return new MessageAuthorizationContext<>(message, path.extractPathVariables(message));
+		if (matcher instanceof Builder.LazySimpDestinationPatternMessageMatcher pathMatcher) {
+			return new MessageAuthorizationContext<>(message, pathMatcher.extractPathVariables(message));
 		}
 		return new MessageAuthorizationContext<>(message);
 	}
@@ -112,7 +113,10 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 
 		private final List<Entry<AuthorizationManager<MessageAuthorizationContext<?>>>> mappings = new ArrayList<>();
 
+		@Deprecated
 		private Supplier<PathMatcher> pathMatcher = AntPathMatcher::new;
+
+		private boolean useHttpPathSeparator = true;
 
 		public Builder() {
 		}
@@ -132,11 +136,11 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * @return the Expression to associate
 		 */
 		public Builder.Constraint nullDestMatcher() {
-			return matchers(SimpDestinationMessageMatcher.NULL_DESTINATION_MATCHER);
+			return matchers(DestinationPathPatternMessageMatcher.NULL_DESTINATION_MATCHER);
 		}
 
 		/**
-		 * Maps a {@link List} of {@link SimpDestinationMessageMatcher} instances.
+		 * Maps a {@link List} of {@link SimpMessageTypeMatcher} instances.
 		 * @param typesToMatch the {@link SimpMessageType} instance to match on
 		 * @return the {@link Builder.Constraint} associated to the matchers.
 		 */
@@ -156,9 +160,28 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * @param patterns the patterns to create
 		 * {@link org.springframework.security.messaging.util.matcher.SimpDestinationMessageMatcher}
 		 * from.
+		 * @deprecated use {@link #destinationPathPatterns(String...)}
 		 */
+		@Deprecated
 		public Builder.Constraint simpDestMatchers(String... patterns) {
 			return simpDestMatchers(null, patterns);
+		}
+
+		/**
+		 * Allows the creation of a security {@link Constraint} applying to messages whose
+		 * destinations match the provided {@code patterns}.
+		 * <p>
+		 * The matching of each pattern is performed by a
+		 * {@link DestinationPathPatternMessageMatcher} instance that matches
+		 * irrespectively of {@link SimpMessageType}. If no destination is found on the
+		 * {@code Message}, then each {@code Matcher} returns false.
+		 * </p>
+		 * @param patterns the destination path patterns to which the security
+		 * {@code Constraint} will be applicable
+		 * @since 6.5
+		 */
+		public Builder.Constraint destinationPathPatterns(String... patterns) {
+			return destinationPathPatterns(null, patterns);
 		}
 
 		/**
@@ -168,9 +191,27 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * @param patterns the patterns to create
 		 * {@link org.springframework.security.messaging.util.matcher.SimpDestinationMessageMatcher}
 		 * from.
+		 * @deprecated use {@link #destinationPathPatterns(String...)}
 		 */
+		@Deprecated
 		public Builder.Constraint simpMessageDestMatchers(String... patterns) {
 			return simpDestMatchers(SimpMessageType.MESSAGE, patterns);
+		}
+
+		/**
+		 * Allows the creation of a security {@link Constraint} applying to messages of
+		 * the type {@code SimpMessageType.MESSAGE} whose destinations match the provided
+		 * {@code patterns}.
+		 * <p>
+		 * The matching of each pattern is performed by a
+		 * {@link DestinationPathPatternMessageMatcher}. If no destination is found on the
+		 * {@code Message}, then each {@code Matcher} returns false.
+		 * @param patterns the patterns to create
+		 * {@link DestinationPathPatternMessageMatcher} from.
+		 * @since 6.5
+		 */
+		public Builder.Constraint simpTypeMessageDestinationPatterns(String... patterns) {
+			return destinationPathPatterns(SimpMessageType.MESSAGE, patterns);
 		}
 
 		/**
@@ -180,9 +221,27 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * @param patterns the patterns to create
 		 * {@link org.springframework.security.messaging.util.matcher.SimpDestinationMessageMatcher}
 		 * from.
+		 * @deprecated use {@link #simpTypeSubscribeDestinationPatterns(String...)}
 		 */
+		@Deprecated
 		public Builder.Constraint simpSubscribeDestMatchers(String... patterns) {
 			return simpDestMatchers(SimpMessageType.SUBSCRIBE, patterns);
+		}
+
+		/**
+		 * Allows the creation of a security {@link Constraint} applying to messages of
+		 * the type {@code SimpMessageType.SUBSCRIBE} whose destinations match the
+		 * provided {@code patterns}.
+		 * <p>
+		 * The matching of each pattern is performed by a
+		 * {@link DestinationPathPatternMessageMatcher}. If no destination is found on the
+		 * {@code Message}, then each {@code Matcher} returns false.
+		 * @param patterns the patterns to create
+		 * {@link DestinationPathPatternMessageMatcher} from.
+		 * @since 6.5
+		 */
+		public Builder.Constraint simpTypeSubscribeDestinationPatterns(String... patterns) {
+			return destinationPathPatterns(SimpMessageType.SUBSCRIBE, patterns);
 		}
 
 		/**
@@ -195,7 +254,9 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * from.
 		 * @return the {@link Builder.Constraint} that is associated to the
 		 * {@link MessageMatcher}
+		 * @deprecated use {@link #destinationPathPatterns(String...)}
 		 */
+		@Deprecated
 		private Builder.Constraint simpDestMatchers(SimpMessageType type, String... patterns) {
 			List<MessageMatcher<?>> matchers = new ArrayList<>(patterns.length);
 			for (String pattern : patterns) {
@@ -206,12 +267,51 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		}
 
 		/**
+		 * Allows the creation of a security {@link Constraint} applying to messages of
+		 * the provided {@code type} whose destinations match the provided
+		 * {@code patterns}.
+		 * <p>
+		 * The matching of each pattern is performed by a
+		 * {@link DestinationPathPatternMessageMatcher}. If no destination is found on the
+		 * {@code Message}, then each {@code Matcher} returns false.
+		 * </p>
+		 * @param type the {@link SimpMessageType} to match on. If null, the
+		 * {@link SimpMessageType} is not considered for matching.
+		 * @param patterns the patterns to create
+		 * {@link DestinationPathPatternMessageMatcher} from.
+		 * @return the {@link Builder.Constraint} that is associated to the
+		 * {@link MessageMatcher}s
+		 * @since 6.5
+		 */
+		private Builder.Constraint destinationPathPatterns(SimpMessageType type, String... patterns) {
+			List<MessageMatcher<?>> matchers = new ArrayList<>(patterns.length);
+			for (String pattern : patterns) {
+				MessageMatcher<Object> matcher = new LazySimpDestinationPatternMessageMatcher(pattern, type,
+						this.useHttpPathSeparator);
+				matchers.add(matcher);
+			}
+			return new Builder.Constraint(matchers);
+		}
+
+		/**
+		 * Instruct this builder to match message destinations using the separator
+		 * configured in
+		 * {@link org.springframework.http.server.PathContainer.Options#MESSAGE_ROUTE}
+		 */
+		public Builder messageRouteSeparator() {
+			this.useHttpPathSeparator = false;
+			return this;
+		}
+
+		/**
 		 * The {@link PathMatcher} to be used with the
 		 * {@link Builder#simpDestMatchers(String...)}. The default is to use the default
 		 * constructor of {@link AntPathMatcher}.
 		 * @param pathMatcher the {@link PathMatcher} to use. Cannot be null.
 		 * @return the {@link Builder} for further customization.
+		 * @deprecated use {@link #messageRouteSeparator()} to alter the path separator
 		 */
+		@Deprecated
 		public Builder simpDestPathMatcher(PathMatcher pathMatcher) {
 			Assert.notNull(pathMatcher, "pathMatcher cannot be null");
 			this.pathMatcher = () -> pathMatcher;
@@ -224,7 +324,9 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 * computation or lookup of the {@link PathMatcher}.
 		 * @param pathMatcher the {@link PathMatcher} to use. Cannot be null.
 		 * @return the {@link Builder} for further customization.
+		 * @deprecated use {@link #messageRouteSeparator()} to alter the path separator
 		 */
+		@Deprecated
 		public Builder simpDestPathMatcher(Supplier<PathMatcher> pathMatcher) {
 			Assert.notNull(pathMatcher, "pathMatcher cannot be null");
 			this.pathMatcher = pathMatcher;
@@ -240,9 +342,7 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 		 */
 		public Builder.Constraint matchers(MessageMatcher<?>... matchers) {
 			List<MessageMatcher<?>> builders = new ArrayList<>(matchers.length);
-			for (MessageMatcher<?> matcher : matchers) {
-				builders.add(matcher);
-			}
+			builders.addAll(Arrays.asList(matchers));
 			return new Builder.Constraint(builders);
 		}
 
@@ -381,6 +481,7 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 
 		}
 
+		@Deprecated
 		private final class LazySimpDestinationMessageMatcher implements MessageMatcher<Object> {
 
 			private final Supplier<SimpDestinationMessageMatcher> delegate;
@@ -412,6 +513,37 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 
 		}
 
+		private static final class LazySimpDestinationPatternMessageMatcher implements MessageMatcher<Object> {
+
+			private final Supplier<DestinationPathPatternMessageMatcher> delegate;
+
+			private LazySimpDestinationPatternMessageMatcher(String pattern, SimpMessageType type,
+					boolean useHttpPathSeparator) {
+				this.delegate = SingletonSupplier.of(() -> {
+					DestinationPathPatternMessageMatcher.Builder builder = (useHttpPathSeparator)
+							? DestinationPathPatternMessageMatcher.withDefaults()
+							: DestinationPathPatternMessageMatcher.messageRoute();
+					if (type == null) {
+						return builder.matcher(pattern);
+					}
+					if (SimpMessageType.MESSAGE == type || SimpMessageType.SUBSCRIBE == type) {
+						return builder.messageType(type).matcher(pattern);
+					}
+					throw new IllegalStateException(type + " is not supported since it does not have a destination");
+				});
+			}
+
+			@Override
+			public boolean matches(Message<?> message) {
+				return this.delegate.get().matches(message);
+			}
+
+			Map<String, String> extractPathVariables(Message<?> message) {
+				return this.delegate.get().extractPathVariables(message);
+			}
+
+		}
+
 	}
 
 	private static final class Entry<T> {
@@ -420,7 +552,7 @@ public final class MessageMatcherDelegatingAuthorizationManager implements Autho
 
 		private final T entry;
 
-		Entry(MessageMatcher requestMatcher, T entry) {
+		Entry(MessageMatcher<?> requestMatcher, T entry) {
 			this.messageMatcher = requestMatcher;
 			this.entry = entry;
 		}

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/DestinationPathPatternMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/DestinationPathPatternMessageMatcher.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.messaging.util.matcher;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.util.Assert;
+import org.springframework.util.RouteMatcher;
+import org.springframework.web.util.pattern.PathPatternParser;
+import org.springframework.web.util.pattern.PathPatternRouteMatcher;
+
+/**
+ * Match {@link Message}s based on the message destination pattern, delegating the
+ * matching to a {@link PathPatternRouteMatcher}. There is also support for optionally
+ * matching on a specified {@link SimpMessageType}.
+ *
+ * @author Pat McCusker
+ * @since 6.5
+ */
+public final class DestinationPathPatternMessageMatcher implements MessageMatcher<Object> {
+
+	public static final MessageMatcher<Object> NULL_DESTINATION_MATCHER = (message) -> getDestination(message) == null;
+
+	private static final PathPatternRouteMatcher SLASH_SEPARATED_ROUTE_MATCHER = new PathPatternRouteMatcher(
+			PathPatternParser.defaultInstance);
+
+	private static final PathPatternRouteMatcher DOT_SEPARATED_ROUTE_MATCHER = new PathPatternRouteMatcher();
+
+	private final String patternToMatch;
+
+	private final PathPatternRouteMatcher delegate;
+
+	/**
+	 * The {@link MessageMatcher} that determines if the type matches. If the type was
+	 * null, this matcher will match every Message.
+	 */
+	private MessageMatcher<Object> messageTypeMatcher = ANY_MESSAGE;
+
+	private DestinationPathPatternMessageMatcher(String pattern, PathPatternRouteMatcher matcher) {
+		this.patternToMatch = pattern;
+		this.delegate = matcher;
+	}
+
+	/**
+	 * Initialize this builder with a {@link PathPatternRouteMatcher} configured with the
+	 * {@link org.springframework.http.server.PathContainer.Options#HTTP_PATH} separator
+	 */
+	public static Builder withDefaults() {
+		return new Builder(SLASH_SEPARATED_ROUTE_MATCHER);
+	}
+
+	/**
+	 * Initialize this builder with a {@link PathPatternRouteMatcher} configured with the
+	 * {@link org.springframework.http.server.PathContainer.Options#MESSAGE_ROUTE}
+	 * separator
+	 */
+	public static Builder messageRoute() {
+		return new Builder(DOT_SEPARATED_ROUTE_MATCHER);
+	}
+
+	void setMessageTypeMatcher(MessageMatcher<Object> messageTypeMatcher) {
+		this.messageTypeMatcher = messageTypeMatcher;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean matches(Message<?> message) {
+		if (!this.messageTypeMatcher.matches(message)) {
+			return false;
+		}
+
+		final String destination = getDestination(message);
+		if (destination == null) {
+			return false;
+		}
+
+		final RouteMatcher.Route destinationRoute = this.delegate.parseRoute(destination);
+		return this.delegate.match(this.patternToMatch, destinationRoute);
+	}
+
+	/**
+	 * Extract the path variables from the {@link Message} destination if the path is a
+	 * match.
+	 * @param message the message whose path variables to extract.
+	 * @return a {@code Map} of the path variables and values.
+	 * @throws IllegalStateException if the path does not match.
+	 */
+	public Map<String, String> extractPathVariables(Message<?> message) {
+		final String destination = getDestination(message);
+		if (destination == null) {
+			return Collections.emptyMap();
+		}
+
+		final RouteMatcher.Route destinationRoute = this.delegate.parseRoute(destination);
+		Map<String, String> pathMatchInfo = this.delegate.matchAndExtract(this.patternToMatch, destinationRoute);
+
+		Assert.state(pathMatchInfo != null,
+				"Pattern \"" + this.patternToMatch + "\" is not a match for \"" + destination + "\"");
+
+		return pathMatchInfo;
+	}
+
+	private static String getDestination(Message<?> message) {
+		return SimpMessageHeaderAccessor.getDestination(message.getHeaders());
+	}
+
+	public static class Builder {
+
+		private final PathPatternRouteMatcher routeMatcher;
+
+		private MessageMatcher<Object> messageTypeMatcher = ANY_MESSAGE;
+
+		Builder(PathPatternRouteMatcher matcher) {
+			this.routeMatcher = matcher;
+		}
+
+		public Builder messageType(SimpMessageType type) {
+			Assert.notNull(type, "Type must not be null");
+			this.messageTypeMatcher = new SimpMessageTypeMatcher(type);
+			return this;
+		}
+
+		public DestinationPathPatternMessageMatcher matcher(String pattern) {
+			Assert.notNull(pattern, "Pattern must not be null");
+			DestinationPathPatternMessageMatcher matcher = new DestinationPathPatternMessageMatcher(pattern,
+					this.routeMatcher);
+			if (this.messageTypeMatcher != ANY_MESSAGE) {
+				matcher.setMessageTypeMatcher(this.messageTypeMatcher);
+			}
+			return matcher;
+		}
+
+	}
+
+}

--- a/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
+++ b/messaging/src/main/java/org/springframework/security/messaging/util/matcher/SimpDestinationMessageMatcher.java
@@ -35,7 +35,9 @@ import org.springframework.util.PathMatcher;
  *
  * @author Rob Winch
  * @since 4.0
+ * @deprecated use {@link DestinationPathPatternMessageMatcher}
  */
+@Deprecated
 public final class SimpDestinationMessageMatcher implements MessageMatcher<Object> {
 
 	public static final MessageMatcher<Object> NULL_DESTINATION_MATCHER = (message) -> {

--- a/messaging/src/test/java/org/springframework/security/messaging/access/intercept/MessageMatcherDelegatingAuthorizationManagerTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/access/intercept/MessageMatcherDelegatingAuthorizationManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public final class MessageMatcherDelegatingAuthorizationManagerTests {
 	void checkWhenPermitAllThenPermits() {
 		AuthorizationManager<Message<?>> authorizationManager = builder().anyMessage().permitAll().build();
 		Message<?> message = new GenericMessage<>(new Object());
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
 	}
 
 	@Test
@@ -51,22 +51,22 @@ public final class MessageMatcherDelegatingAuthorizationManagerTests {
 		AuthorizationManager<Message<?>> authorizationManager = builder().anyMessage().hasRole("USER").build();
 		Message<?> message = new GenericMessage<>(new Object());
 		Authentication user = new TestingAuthenticationToken("user", "password", "ROLE_USER");
-		assertThat(authorizationManager.check(() -> user, message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(() -> user, message).isGranted()).isTrue();
 		Authentication admin = new TestingAuthenticationToken("user", "password", "ROLE_ADMIN");
-		assertThat(authorizationManager.check(() -> admin, message).isGranted()).isFalse();
+		assertThat(authorizationManager.authorize(() -> admin, message).isGranted()).isFalse();
 	}
 
 	@Test
 	void checkWhenSimpDestinationMatchesThenUses() {
-		AuthorizationManager<Message<?>> authorizationManager = builder().simpDestMatchers("destination")
+		AuthorizationManager<Message<?>> authorizationManager = builder().destinationPathPatterns("/destination")
 			.permitAll()
 			.anyMessage()
 			.denyAll()
 			.build();
 		MessageHeaders headers = new MessageHeaders(
-				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "destination"));
+				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination"));
 		Message<?> message = new GenericMessage<>(new Object(), headers);
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
 	}
 
 	@Test
@@ -77,11 +77,11 @@ public final class MessageMatcherDelegatingAuthorizationManagerTests {
 			.denyAll()
 			.build();
 		Message<?> message = new GenericMessage<>(new Object());
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
 		MessageHeaders headers = new MessageHeaders(
-				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "destination"));
+				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination"));
 		message = new GenericMessage<>(new Object(), headers);
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isFalse();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isFalse();
 	}
 
 	@Test
@@ -94,21 +94,69 @@ public final class MessageMatcherDelegatingAuthorizationManagerTests {
 		MessageHeaders headers = new MessageHeaders(
 				Map.of(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.CONNECT));
 		Message<?> message = new GenericMessage<>(new Object(), headers);
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
+	}
+
+	@Test
+	void checkWhenMessageTypeAndPathPatternMatches() {
+		AuthorizationManager<Message<?>> authorizationManager = builder()
+			.simpTypeMessageDestinationPatterns("/destination")
+			.permitAll()
+			.simpTypeSubscribeDestinationPatterns("/destination")
+			.denyAll()
+			.anyMessage()
+			.denyAll()
+			.build();
+		MessageHeaders headers = new MessageHeaders(Map.of(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER,
+				SimpMessageType.MESSAGE, SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination"));
+		Message<?> message = new GenericMessage<>(new Object(), headers);
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
+		MessageHeaders headers2 = new MessageHeaders(Map.of(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER,
+				SimpMessageType.SUBSCRIBE, SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination"));
+		Message<?> message2 = new GenericMessage<>(new Object(), headers2);
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message2).isGranted()).isFalse();
+	}
+
+	@Test
+	void checkWhenMessageRouteAndPatternMismatch() {
+		AuthorizationManager<Message<?>> authorizationManager = builder().messageRouteSeparator()
+			.destinationPathPatterns("/destination.*")
+			.permitAll()
+			.anyMessage()
+			.denyAll()
+			.build();
+		MessageHeaders headers = new MessageHeaders(
+				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination.sub.asdf"));
+		Message<?> message = new GenericMessage<>(new Object(), headers);
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isFalse();
 	}
 
 	// gh-12540
 	@Test
 	void checkWhenSimpDestinationMatchesThenVariablesExtracted() {
-		AuthorizationManager<Message<?>> authorizationManager = builder().simpDestMatchers("destination/{id}")
+		AuthorizationManager<Message<?>> authorizationManager = builder().destinationPathPatterns("/destination/{id}")
 			.access(variable("id").isEqualTo("3"))
 			.anyMessage()
 			.denyAll()
 			.build();
 		MessageHeaders headers = new MessageHeaders(
-				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "destination/3"));
+				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/3"));
 		Message<?> message = new GenericMessage<>(new Object(), headers);
-		assertThat(authorizationManager.check(mock(Supplier.class), message).isGranted()).isTrue();
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
+	}
+
+	@Test
+	void checkWhenMessageRouteDestinationMatchesThenVariablesExtracted() {
+		AuthorizationManager<Message<?>> authorizationManager = builder().messageRouteSeparator()
+			.destinationPathPatterns("/destination.{id}")
+			.access(variable("id").isEqualTo("3"))
+			.anyMessage()
+			.denyAll()
+			.build();
+		MessageHeaders headers = new MessageHeaders(
+				Map.of(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination.3"));
+		Message<?> message = new GenericMessage<>(new Object(), headers);
+		assertThat(authorizationManager.authorize(mock(Supplier.class), message).isGranted()).isTrue();
 	}
 
 	private MessageMatcherDelegatingAuthorizationManager.Builder builder() {
@@ -120,13 +168,7 @@ public final class MessageMatcherDelegatingAuthorizationManagerTests {
 
 	}
 
-	private static final class Builder {
-
-		private final String name;
-
-		private Builder(String name) {
-			this.name = name;
-		}
+	private record Builder(String name) {
 
 		AuthorizationManager<MessageAuthorizationContext<?>> isEqualTo(String value) {
 			return (authentication, object) -> {

--- a/messaging/src/test/java/org/springframework/security/messaging/util/matcher/DestinationPathPatternMessageMatcherTests.java
+++ b/messaging/src/test/java/org/springframework/security/messaging/util/matcher/DestinationPathPatternMessageMatcherTests.java
@@ -22,72 +22,80 @@ import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.AntPathMatcher;
-import org.springframework.util.PathMatcher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-public class SimpDestinationMessageMatcherTests {
+public class DestinationPathPatternMessageMatcherTests {
 
 	MessageBuilder<String> messageBuilder;
 
-	SimpDestinationMessageMatcher matcher;
-
-	PathMatcher pathMatcher;
+	DestinationPathPatternMessageMatcher matcher;
 
 	@BeforeEach
-	public void setup() {
+	void setUp() {
 		this.messageBuilder = MessageBuilder.withPayload("M");
-		this.matcher = new SimpDestinationMessageMatcher("/**");
-		this.pathMatcher = new AntPathMatcher();
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/**");
 	}
 
 	@Test
-	public void constructorPatternNull() {
-		assertThatIllegalArgumentException().isThrownBy(() -> new SimpDestinationMessageMatcher(null));
-	}
-
-	public void constructorOnlyPathNoError() {
-		new SimpDestinationMessageMatcher("/path");
+	void constructorPatternNull() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> DestinationPathPatternMessageMatcher.withDefaults().matcher(null));
 	}
 
 	@Test
-	public void matchesDoesNotMatchNullDestination() {
+	void matchesDoesNotMatchNullDestination() {
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isFalse();
 	}
 
 	@Test
-	public void matchesAllWithDestination() {
+	void matchesTrueWithSpecificDestinationPattern() {
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/destination/1");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/1");
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
 	}
 
 	@Test
-	public void matchesSpecificWithDestination() {
-		this.matcher = new SimpDestinationMessageMatcher("/destination/1");
-		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/1");
-		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
-	}
-
-	@Test
-	public void matchesFalseWithDestination() {
-		this.matcher = new SimpDestinationMessageMatcher("/nomatch");
+	void matchesFalseWithDifferentDestination() {
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/nomatch");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/1");
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isFalse();
 	}
 
 	@Test
-	public void matchesFalseMessageTypeNotDisconnectType() {
-		this.matcher = SimpDestinationMessageMatcher.createMessageMatcher("/match", this.pathMatcher);
+	void matchesTrueWithDotSeparator() {
+		this.matcher = DestinationPathPatternMessageMatcher.messageRoute().matcher("destination.1");
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "destination.1");
+		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
+	}
+
+	@Test
+	void matchesFalseWithDotSeparatorAndAdditionalWildcardPathSegment() {
+		this.matcher = DestinationPathPatternMessageMatcher.messageRoute().matcher("/destination/a.*");
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/a.b");
+		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/a.b.c");
+		assertThat(this.matcher.matches(this.messageBuilder.build())).isFalse();
+	}
+
+	@Test
+	void matchesFalseWithDifferentMessageType() {
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults()
+			.messageType(SimpMessageType.MESSAGE)
+			.matcher("/match");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.DISCONNECT);
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/match");
+
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isFalse();
 	}
 
 	@Test
 	public void matchesTrueMessageType() {
-		this.matcher = SimpDestinationMessageMatcher.createMessageMatcher("/match", this.pathMatcher);
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults()
+			.messageType(SimpMessageType.MESSAGE)
+			.matcher("/match");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/match");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.MESSAGE);
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
@@ -95,44 +103,41 @@ public class SimpDestinationMessageMatcherTests {
 
 	@Test
 	public void matchesTrueSubscribeType() {
-		this.matcher = SimpDestinationMessageMatcher.createSubscribeMatcher("/match", this.pathMatcher);
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults()
+			.messageType(SimpMessageType.SUBSCRIBE)
+			.matcher("/match");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/match");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.SUBSCRIBE);
 		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
 	}
 
 	@Test
-	public void matchesNullMessageType() {
-		this.matcher = new SimpDestinationMessageMatcher("/match");
-		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/match");
-		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.MESSAGE);
-		assertThat(this.matcher.matches(this.messageBuilder.build())).isTrue();
-	}
-
-	@Test
-	public void extractPathVariablesFromDestination() {
-		this.matcher = new SimpDestinationMessageMatcher("/topics/{topic}/**");
+	void extractPathVariablesFromDestination() {
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/topics/{topic}/**");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/topics/someTopic/sub1");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.MESSAGE);
+
 		assertThat(this.matcher.extractPathVariables(this.messageBuilder.build())).containsEntry("topic", "someTopic");
 	}
 
 	@Test
-	public void extractedVariablesAreEmptyInNullDestination() {
-		this.matcher = new SimpDestinationMessageMatcher("/topics/{topic}/**");
+	void extractPathVariablesFromMessageDestinationPath() {
+		this.matcher = DestinationPathPatternMessageMatcher.messageRoute().matcher("destination.{destinationNum}");
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "destination.1");
+		assertThat(this.matcher.extractPathVariables(this.messageBuilder.build())).containsEntry("destinationNum", "1");
+	}
+
+	@Test
+	void extractPathVariables_isEmptyWithNullDestination() {
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/topics/{topic}/**");
+		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.MESSAGE_TYPE_HEADER, SimpMessageType.MESSAGE);
+
 		assertThat(this.matcher.extractPathVariables(this.messageBuilder.build())).isEmpty();
 	}
 
 	@Test
-	public void typeConstructorParameterIsTransmitted() {
-		this.matcher = SimpDestinationMessageMatcher.createMessageMatcher("/match", this.pathMatcher);
-		MessageMatcher<Object> expectedTypeMatcher = new SimpMessageTypeMatcher(SimpMessageType.MESSAGE);
-		assertThat(this.matcher.getMessageTypeMatcher()).isEqualTo(expectedTypeMatcher);
-	}
-
-	@Test
 	void illegalStateExceptionThrown_onExtractPathVariables_whenNoMatch() {
-		this.matcher = new SimpDestinationMessageMatcher("/nomatch");
+		this.matcher = DestinationPathPatternMessageMatcher.withDefaults().matcher("/nomatch");
 		this.messageBuilder.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "/destination/1");
 		assertThatIllegalStateException()
 			.isThrownBy(() -> this.matcher.extractPathVariables(this.messageBuilder.build()));


### PR DESCRIPTION
### **User description**
Closes gh-16500

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `DestinationPathPatternMessageMatcher` for enhanced message matching.
  - Supports matching message destinations using patterns and message types.
  - Replaces the deprecated `SimpDestinationMessageMatcher`.

- Deprecated `SimpDestinationMessageMatcher` and related methods in favor of the new matcher.

- Added new test cases for `DestinationPathPatternMessageMatcher` to validate functionality.
  - Includes tests for matching patterns, extracting path variables, and handling edge cases.

- Updated existing tests to use the new `DestinationPathPatternMessageMatcher`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>WebSocketMessageBrokerSecurityConfigurationDocTests.java</strong><dd><code>Updated copyright year to 2025</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-3cbf39ef1f1bef8dd436dba587cc4a7145590f363562121c91ef8a56f4decf19">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>WebSocketMessageBrokerSecurityConfigurationTests.java</strong><dd><code>Updated copyright year to 2025</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-e8b69a9759d6d22eac8e0483dbbabfc5b1a7f2443aca436e6211b4568dd772e0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>MessageMatcherDelegatingAuthorizationManager.java</strong><dd><code>Integrated <code>DestinationPathPatternMessageMatcher</code> and deprecated old <br>matchers</code></dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-5de280fed3b2c3970c2affa7e86ba0c8f6de9d5ea039cb9b77483c1e0e329358">+144/-12</a></td>

</tr>

<tr>
  <td><strong>DestinationPathPatternMessageMatcher.java</strong><dd><code>Added new `DestinationPathPatternMessageMatcher` implementation</code></dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-bc115193e907dfc835357e36e552b036b472bf7203ed69b6641d05b3232c578c">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SimpDestinationMessageMatcher.java</strong><dd><code>Deprecated `SimpDestinationMessageMatcher` in favor of new matcher</code></dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-9b0b05858255232f04ecbb2825d309f51a746c7cef18eebfb27c5a88c14ca6f7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>MessageMatcherDelegatingAuthorizationManagerTests.java</strong><dd><code>Updated tests to use `DestinationPathPatternMessageMatcher`</code></dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-928b46e89a5dcea9ce1af1aa786373952b186367a3aeb370772f2ccbdaf3e6ef">+63/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DestinationPathPatternMessageMatcherTests.java</strong><dd><code>Added tests for `DestinationPathPatternMessageMatcher`</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-6ab1e5e835fac1b0751b558e8e4baf939ef934991f0393f4570f3d986dc1a9e6">+146/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>SimpDestinationMessageMatcherTests.java</strong><dd><code>Added edge case tests for deprecated `SimpDestinationMessageMatcher`</code></dd></td>
  <td><a href="https://github.com/GuusArts/spring-security/pull/18/files#diff-2ee6d2e0dde28daa10aa30b2c249500d7de8408f52c0cba0be1dda99ba27a0cf">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>