### PR TITLE
Fix JdbcUserCredentialRepository Save initial commit 16621

### DIFF
--- a/web/src/main/java/org/springframework/security/web/webauthn/management/JdbcUserCredentialRepository.java
+++ b/web/src/main/java/org/springframework/security/web/webauthn/management/JdbcUserCredentialRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.PreparedStatementSetter;
@@ -112,6 +113,24 @@ public final class JdbcUserCredentialRepository implements UserCredentialReposit
 
 	private static final String DELETE_CREDENTIAL_RECORD_SQL = "DELETE FROM " + TABLE_NAME + " WHERE " + ID_FILTER;
 
+	// @formatter:off
+	private static final String UPDATE_CREDENTIAL_RECORD_SQL = "UPDATE " + TABLE_NAME
+			+ " SET user_entity_user_id = ?, " +
+			"public_key = ?, " +
+			"signature_count = ?, " +
+			"uv_initialized = ?, " +
+			"backup_eligible = ? ," +
+			"authenticator_transports = ?, " +
+			"public_key_credential_type = ?, " +
+			"backup_state = ?, " +
+			"attestation_object = ?, " +
+			"attestation_client_data_json = ?, " +
+			"created = ?, " +
+			"last_used = ?, " +
+			"label = ?"
+			+ " WHERE " + ID_FILTER;
+	// @formatter:on
+
 	/**
 	 * Constructs a {@code JdbcUserCredentialRepository} using the provided parameters.
 	 * @param jdbcOperations the JDBC operations
@@ -133,11 +152,37 @@ public final class JdbcUserCredentialRepository implements UserCredentialReposit
 	@Override
 	public void save(CredentialRecord record) {
 		Assert.notNull(record, "record cannot be null");
+		boolean existsRecord = null != this.findByCredentialId(record.getCredentialId());
+		if (existsRecord) {
+			updateCredentialRecord(record);
+		}
+		else {
+			try {
+				insertCredentialRecord(record);
+			}
+			catch (DuplicateKeyException ex) {
+				updateCredentialRecord(record);
+			}
+		}
+	}
+
+	private void insertCredentialRecord(CredentialRecord record) {
 		List<SqlParameterValue> parameters = this.credentialRecordParametersMapper.apply(record);
 		try (LobCreator lobCreator = this.lobHandler.getLobCreator()) {
 			PreparedStatementSetter pss = new LobCreatorArgumentPreparedStatementSetter(lobCreator,
 					parameters.toArray());
 			this.jdbcOperations.update(SAVE_CREDENTIAL_RECORD_SQL, pss);
+		}
+	}
+
+	private void updateCredentialRecord(CredentialRecord record) {
+		List<SqlParameterValue> parameters = this.credentialRecordParametersMapper.apply(record);
+		SqlParameterValue credentialId = parameters.remove(0);
+		parameters.add(credentialId);
+		try (LobCreator lobCreator = this.lobHandler.getLobCreator()) {
+			PreparedStatementSetter pss = new LobCreatorArgumentPreparedStatementSetter(lobCreator,
+					parameters.toArray());
+			this.jdbcOperations.update(UPDATE_CREDENTIAL_RECORD_SQL, pss);
 		}
 	}
 


### PR DESCRIPTION
Closes gh-16620

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

## Summary by Sourcery

Improve the save mechanism for WebAuthn credential records in the JDBC repository to handle existing records and prevent duplicate key exceptions

Bug Fixes:
- Add logic to update existing credential records instead of always inserting new records, preventing potential data duplication issues

Enhancements:
- Implement a more robust save method that checks for existing records and handles updates appropriately
- Add an UPDATE SQL statement to modify existing credential records

Tests:
- Add a test case to verify updating an existing credential record with new information