### PR TITLE
Add support checking same security matchers human reviewers

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java
@@ -44,6 +44,7 @@ import org.springframework.security.config.annotation.web.WebSecurityConfigurer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.DefaultFilterChainValidator;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
@@ -338,6 +339,7 @@ public final class WebSecurity extends AbstractConfiguredSecurityBuilder<Filter,
 			filterChainProxy.setRequestRejectedHandler(requestRejectedHandler);
 		}
 		filterChainProxy.setFilterChainDecorator(getFilterChainDecorator());
+		filterChainProxy.setFilterChainValidator(new DefaultFilterChainValidator());
 		filterChainProxy.afterPropertiesSet();
 
 		Filter result = filterChainProxy;

--- a/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
+++ b/web/src/main/java/org/springframework/security/web/util/matcher/OrRequestMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.security.web.util.matcher;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -79,6 +80,23 @@ public final class OrRequestMatcher implements RequestMatcher {
 			}
 		}
 		return MatchResult.notMatch();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		OrRequestMatcher that = (OrRequestMatcher) o;
+		return Objects.equals(this.requestMatchers, that.requestMatchers);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.requestMatchers);
 	}
 
 	@Override


### PR DESCRIPTION
Closes gh-15982

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->

## Summary by Sourcery

Add validation to prevent duplicate security matchers in Spring Security configuration

New Features:
- Implement validation to detect and prevent multiple security filter chains with identical request matchers

Enhancements:
- Add equals and hashCode methods to OrRequestMatcher to support matcher comparison
- Improve filter chain validation to check for duplicate security matchers

Tests:
- Add test case to verify that configuring multiple security filter chains with the same matcher throws an exception